### PR TITLE
feat: implement persistent terminal sessions

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -104,6 +104,10 @@ func runServer(cmd *cobra.Command, args []string) {
 	chatHandler := handlers.NewChatHandler(chatRepo, sessionRepo)
 	terminalHandler := handlers.NewTerminalHandler(sessionService)
 	
+	// Set cross-handler dependencies
+	sessionHandler.SetWebSocketHandler(websocketHandler)
+	sessionHandler.SetTerminalHandler(terminalHandler)
+	
 	// Start WebSocket hub
 	websocketHandler.StartHub()
 	

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -109,6 +109,9 @@ func (r *Router) SetupRoutes(engine *gin.Engine) {
 
 	// Terminal WebSocket endpoint
 	api.GET("/terminal/:sessionId", r.terminalHandler.HandleTerminalWebSocket)
+	
+	// Terminal restart endpoint
+	api.POST("/terminal/:sessionId/restart", r.terminalHandler.RestartTerminal)
 
 	// WebSocket endpoint (also available on root for compatibility)
 	engine.GET("/ws", r.websocketHandler.HandleWebSocket)

--- a/web/src/hooks/useTerminalManager.ts
+++ b/web/src/hooks/useTerminalManager.ts
@@ -9,6 +9,7 @@ interface TerminalInstance {
   ws: WebSocket | null
   sessionId: number
   container: HTMLDivElement | null
+  onDataDisposer?: { dispose: () => void }
 }
 
 export function useTerminalManager() {
@@ -101,6 +102,9 @@ export function useTerminalManager() {
     if (instance) {
       if (instance.ws && instance.ws.readyState === WebSocket.OPEN) {
         instance.ws.close(1000)
+      }
+      if (instance.onDataDisposer) {
+        instance.onDataDisposer.dispose()
       }
       instance.terminal.dispose()
       terminalsRef.current.delete(sessionId)


### PR DESCRIPTION
- Terminal processes now persist when switching between tabs
- Added support for multiple WebSocket connections to same terminal
- Implemented output buffer to show recent terminal output on reconnection
- Added "Restart" button to manually restart terminal processes
- Fixed duplicate input handler bug that occurred on terminal restart
- Terminal cleanup now properly happens on session deletion

The terminal sessions maintain state and running processes while allowing users to switch between tabs freely, with option to manually restart when needed.

🤖 Generated with [Claude Code](https://claude.ai/code)